### PR TITLE
added check for existing join to fix acl resource error

### DIFF
--- a/Model/ResourceModel/SizeGuide/Collection.php
+++ b/Model/ResourceModel/SizeGuide/Collection.php
@@ -85,9 +85,10 @@ class Collection extends AbstractCollection
      */
     public function addStoreFilter($storeId): Collection
     {
-        $this->getSelect()
-            ->where('`store_id` = ?', $storeId);
-
+        if ($this->_joinedTables !== []) {
+            $this->getSelect()
+                ->where('`store_id` = ?', $storeId);
+        }
         return $this;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "magento/magento-composer-installer": "*"
     },
     "type": "magento2-module",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
ACL resource is checked on login and errors with unknown column 'store_id'. Join is unnecessary as this is a resource check only, hence fix to check for existence of join fixes ACL validation on login.